### PR TITLE
[fix]音楽が再生されないバグを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
   );
       }
     </style>
+    <audio preload="auto" autoplay loop>
+    <source src="bgm.mp3">
+    <source src="bgm.ogg">
+  </audio>
   </head>
   <body>
     <canvas id="field" width="300" height="600"></canvas>
@@ -31,9 +35,4 @@
     <script type="text/javascript" src="./scripts/mino.js"></script>
     <script type="text/javascript" src="./scripts/main.js"></script>
   </body>
-  <audio preload="auto" autoplay loop>
-    <source src="bgm.mp3">
-    <source src="bgm.ogg">
-    <source src="bgm.m4a">
-  </audio>
 </html>


### PR DESCRIPTION
<audio>要素を適切な位置へ移動，m4aのソース要素が指定されていなかったため削除した．現在は再生可能．